### PR TITLE
Fix xcom::StrBuf::strcat undefined issue.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -32,6 +32,7 @@ xocfe_SOURCES = \
                 com/comf.cpp \
                 com/bs.cpp \
                 com/ltype.cpp \
+                com/strbuf.cpp \
                 \
                 opt/label.cpp \
                 opt/util.cpp


### PR DESCRIPTION
Hi @stevenknown 

```
g++ -Wno-write-strings -Wsign-promo -Wsign-compare -Wpointer-arith -Wno-multichar -Winit-self -Wstrict-aliasing=3 -D_DEBUG_ -Wswitch -fno-rtti -fno-exceptions -g -O2   -o xocfe xocfe.o decl.o err.o exectree.o lex.o scope.o st.o tree.o treegen.o typeck.o cell.o smempool.o comf.o bs.o ltype.o label.o util.o  
decl.o：在函数‘format_struct_union(xcom::StrBuf&, TypeSpec const*)’中：
/data/project/LLVM-China/xocfe/src/cfe/decl.cpp:3440：对‘xcom::StrBuf::strcat(char const*, ...)’未定义的引用
/data/project/LLVM-China/xocfe/src/cfe/decl.cpp:3455：对‘xcom::StrBuf::strcat(char const*, ...)’未定义的引用
/data/project/LLVM-China/xocfe/src/cfe/decl.cpp:3438：对‘xcom::StrBuf::strcat(char const*, ...)’未定义的引用
decl.o：在函数‘format_base_type_spec(xcom::StrBuf&, TypeSpec const*) [clone .part.11]’中：
/data/project/LLVM-China/xocfe/src/cfe/decl.cpp:3318：对‘xcom::StrBuf::strcat(char const*, ...)’未定义的引用
/data/project/LLVM-China/xocfe/src/cfe/decl.cpp:3316：对‘xcom::StrBuf::strcat(char const*, ...)’未定义的引用
decl.o:/data/project/LLVM-China/xocfe/src/cfe/decl.cpp:3314: 跟着更多未定义的参考到 xcom::StrBuf::strcat(char const*, ...)
err.o：在函数‘warn(int, char*, ...)’中：
/data/project/LLVM-China/xocfe/src/cfe/err.cpp:74：对‘xcom::StrBuf::vsprint(char const*, __va_list_tag*)’未定义的引用
err.o：在函数‘err(int, char*, ...)’中：
/data/project/LLVM-China/xocfe/src/cfe/err.cpp:94：对‘xcom::StrBuf::vsprint(char const*, __va_list_tag*)’未定义的引用
tree.o：在函数‘dump_tree(Tree*)’中：
/data/project/LLVM-China/xocfe/src/cfe/tree.cpp:105：对‘xcom::StrBuf::strcat(char const*, ...)’未定义的引用
util.o：在函数‘xoc::interwarn(char const*, ...)’中：
/data/project/LLVM-China/xocfe/src/opt/util.cpp:55：对‘xcom::StrBuf::vsprint(char const*, __va_list_tag*)’未定义的引用
util.o：在函数‘xoc::note(char const*, ...)’中：
/data/project/LLVM-China/xocfe/src/opt/util.cpp:114：对‘xcom::StrBuf::vstrcat(char const*, __va_list_tag*)’未定义的引用
collect2: 错误：ld 返回 1
make[2]: *** [Makefile:375：xocfe] 错误 1
make[2]: 离开目录“/data/project/LLVM-China/xocfe/src”
make[1]: *** [Makefile:410：all-recursive] 错误 1
make[1]: 离开目录“/data/project/LLVM-China/xocfe”
make: *** [Makefile:330：all] 错误 2
```

So I simply added ```com/strbuf.cpp``` to src/Makefile.am, please review it, thanks a lot!

Regards,
Leslie Zhai - a [LLVM developer](https://reviews.llvm.org/p/xiangzhai/)